### PR TITLE
fix: tell type checks that the config options are strings

### DIFF
--- a/src/blackbox.py
+++ b/src/blackbox.py
@@ -10,7 +10,7 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
-from typing import Optional
+from typing import Optional, cast
 
 import yaml
 from ops.framework import Object
@@ -156,7 +156,7 @@ class WorkloadManager(Object):
         if not self.is_ready:
             raise ContainerNotReady("cannot update config")
         logger.debug("applying config changes")
-        config = self.model.config.get("config_file")
+        config = cast(Optional[str], self.model.config.get("config_file"))
         # Basic config validation: valid yaml
         if config:
             try:

--- a/src/charm.py
+++ b/src/charm.py
@@ -238,7 +238,9 @@ class BlackboxExporterCharm(CharmBase):
         jobs = []
         external_url = urlparse(self._external_url)
         f"{external_url.path.rstrip('/')}/probe"
-        probes_scrape_jobs = typing.cast(typing.Optional[str], self.model.config.get("probes_file"))
+        probes_scrape_jobs = typing.cast(
+            typing.Optional[str], self.model.config.get("probes_file")
+        )
         if probes_scrape_jobs:
             probes = yaml.safe_load(probes_scrape_jobs)
             # Add the Blackbox Exporter's `relabel_configs` to each job

--- a/src/charm.py
+++ b/src/charm.py
@@ -6,6 +6,7 @@
 
 import logging
 import socket
+import typing
 from urllib.parse import urlparse
 
 import yaml
@@ -237,7 +238,7 @@ class BlackboxExporterCharm(CharmBase):
         jobs = []
         external_url = urlparse(self._external_url)
         f"{external_url.path.rstrip('/')}/probe"
-        probes_scrape_jobs = self.model.config.get("probes_file")
+        probes_scrape_jobs = typing.cast(typing.Optional[str], self.model.config.get("probes_file"))
         if probes_scrape_jobs:
             probes = yaml.safe_load(probes_scrape_jobs)
             # Add the Blackbox Exporter's `relabel_configs` to each job


### PR DESCRIPTION
ops<=2.12 wrongly has `self.config[x]` typed as `str`, when actually it could be an int, float, bool, or str, depending on the config type. We're fixing this in [ops:#1183](https://github.com/canonical/operator/pull/1183), but that will break static checking that currently assumes that the config is a str (because ops doesn't validate the schema, so all options will be bool|int|float|str).

This PR adds a `typing.cast` call where the config values are loaded and used where the type should be str.