### PR TITLE
add open port support

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -50,6 +50,7 @@ class BlackboxExporterCharm(CharmBase):
         super().__init__(*args)
 
         self.container = self.unit.get_container(self._container_name)
+        self.unit.open_port(protocol="tcp", port=self._port)
         self.ingress = IngressPerAppRequirer(
             self,
             port=self._port,


### PR DESCRIPTION
## Issue

Use `ops.Unit.open_port` for the port to show up in Juju status.

Due to a Juju bug, it might not show up there yet; use `juju exec <unit> -- opened-ports` to verify.

## Testing Instructions

```
charmcraft pack
juju deploy ./blackbox-exporter-k8s_ubuntu-22.04-amd64.charm blackbox
# Wait for the charm
juju exec --unit blackbox/0 -- opened-ports
```