### PR TITLE
Fix traefik integration

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -10,3 +10,5 @@ jobs:
     name: PR
     uses: canonical/observability/.github/workflows/charm-pull-request.yaml@main
     secrets: inherit
+    with:
+      charmcraft-channel: "3.x/stable"

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -10,5 +10,3 @@ jobs:
     name: PR
     uses: canonical/observability/.github/workflows/charm-pull-request.yaml@main
     secrets: inherit
-    with:
-      charmcraft-channel: "3.x/stable"

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -11,4 +11,4 @@ bases:
       channel: "22.04"
 parts:
   charm:
-    charm-binary-python-packages: [ops, PyYAML, cryptography, jsonschema]
+    charm-binary-python-packages: [ops, PyYAML, cryptography, jsonschema, pydantic-core]

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -11,4 +11,5 @@ bases:
       channel: "22.04"
 parts:
   charm:
+    build-packages: [cargo, rustc, pkg-config, libffi-dev, libssl-dev]
     charm-binary-python-packages: [ops, PyYAML, cryptography, jsonschema, pydantic-core]

--- a/src/charm.py
+++ b/src/charm.py
@@ -10,7 +10,6 @@ from typing import cast
 from urllib.parse import urlparse
 
 import yaml
-from blackbox import ConfigUpdateFailure, WorkloadManager
 from charms.catalogue_k8s.v1.catalogue import CatalogueConsumer, CatalogueItem
 from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
 from charms.loki_k8s.v1.loki_push_api import LogForwarder
@@ -31,6 +30,8 @@ from ops.model import (
     WaitingStatus,
 )
 from ops.pebble import PathError, ProtocolError
+
+from blackbox import ConfigUpdateFailure, WorkloadManager
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +66,7 @@ class BlackboxExporterCharm(CharmBase):
             self,
             container_name=self._container_name,
             port=self._port,
-            web_external_url='',
+            web_external_url="",
             config_path=self._config_path,
             log_path=self._log_path,
         )
@@ -220,9 +221,7 @@ class BlackboxExporterCharm(CharmBase):
         external_url = urlparse(self._external_url)
         metrics_path = f"{external_url.path.rstrip('/')}/metrics"
         internal_url = self._internal_url.replace("http://", "")
-        target = (
-            f"{internal_url}"
-        )
+        target = f"{internal_url}"
         job = {
             "metrics_path": metrics_path,
             "static_configs": [{"targets": [target]}],

--- a/src/charm.py
+++ b/src/charm.py
@@ -65,7 +65,7 @@ class BlackboxExporterCharm(CharmBase):
             self,
             container_name=self._container_name,
             port=self._port,
-            web_external_url=self._internal_url,
+            web_external_url='',
             config_path=self._config_path,
             log_path=self._log_path,
         )
@@ -117,7 +117,7 @@ class BlackboxExporterCharm(CharmBase):
             charm=self,
             item=CatalogueItem(
                 name="Blackbox Exporter",
-                url=self._external_url,
+                url=self._external_url + "/",
                 icon="box-variant",
                 description=(
                     "Blackbox exporter allows blackbox probing of endpoints over a multitude of "

--- a/src/charm.py
+++ b/src/charm.py
@@ -65,7 +65,7 @@ class BlackboxExporterCharm(CharmBase):
             self,
             container_name=self._container_name,
             port=self._port,
-            web_external_url=self._external_url,
+            web_external_url=self._internal_url,
             config_path=self._config_path,
             log_path=self._log_path,
         )

--- a/src/charm.py
+++ b/src/charm.py
@@ -219,8 +219,9 @@ class BlackboxExporterCharm(CharmBase):
         """The self-monitoring scrape job."""
         external_url = urlparse(self._external_url)
         metrics_path = f"{external_url.path.rstrip('/')}/metrics"
+        internal_url = self._internal_url.replace("http://", "")
         target = (
-            f"{external_url.hostname}{':'+str(external_url.port) if external_url.port else ''}"
+            f"{internal_url}"
         )
         job = {
             "metrics_path": metrics_path,
@@ -250,7 +251,7 @@ class BlackboxExporterCharm(CharmBase):
                     # Set the address to scrape to the blackbox exporter url
                     {
                         "target_label": "__address__",
-                        "replacement": self._external_url.replace("http://", ""),
+                        "replacement": self._internal_url.replace("http://", ""),
                     },
                 ]
                 jobs.append(probe)

--- a/src/charm.py
+++ b/src/charm.py
@@ -235,7 +235,7 @@ class BlackboxExporterCharm(CharmBase):
         """The scraping jobs to execute probes from Prometheus."""
         jobs = []
         external_url = urlparse(self._external_url)
-        probes_path =  f"{external_url.path.rstrip('/')}/probe"
+        probes_path = f"{external_url.path.rstrip('/')}/probe"
         probes_scrape_jobs = cast(str, self.model.config.get("probes_file"))
         if probes_scrape_jobs:
             probes = yaml.safe_load(probes_scrape_jobs)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -10,13 +10,14 @@
 4. Scales down the application to below the leader unit, to trigger a leadership change event
 """
 
-
+import asyncio
 import logging
 from pathlib import Path
 
 import pytest
+import requests
 import yaml
-from helpers import can_blackbox_probe, is_blackbox_up
+from helpers import can_blackbox_probe, get_traefik_proxied_endpoints, is_blackbox_up
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
@@ -28,6 +29,7 @@ resources = {
 }
 
 
+@pytest.mark.setup
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest, charm_under_test):
     """Build the charm-under-test and deploy it together with related charms.
@@ -35,8 +37,11 @@ async def test_build_and_deploy(ops_test: OpsTest, charm_under_test):
     Assert on the unit status before any relations/configurations take place.
     """
     # deploy charm from local source folder
-    await ops_test.model.deploy(
-        charm_under_test, resources=resources, application_name=app_name, trust=True
+    await asyncio.gather(
+        ops_test.model.deploy(
+            charm_under_test, resources=resources, application_name=app_name, trust=True
+        ),
+        ops_test.model.deploy("traefik-k8s", "traefik", channel="latest/edge", trust=True),
     )
     await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
     assert ops_test.model.applications[app_name].units[0].workload_status == "active"
@@ -46,3 +51,29 @@ async def test_build_and_deploy(ops_test: OpsTest, charm_under_test):
 @pytest.mark.abort_on_fail
 async def test_probe_endpoint(ops_test: OpsTest):
     assert await can_blackbox_probe(ops_test, app_name, 0)
+
+
+@pytest.mark.setup
+@pytest.mark.abort_on_fail
+async def test_integrate_traefik(ops_test: OpsTest):
+    assert ops_test.model is not None
+    await ops_test.model.integrate(f"{app_name}:ingress", "traefik")
+
+    await ops_test.model.wait_for_idle(
+        apps=[
+            app_name,
+            "traefik",
+        ],
+        status="active",
+    )
+
+
+@pytest.mark.abort_on_fail
+async def test_traefik(ops_test: OpsTest):
+    """Check the ingress integration, by checking if blackbox is reachable through Traefik."""
+    assert ops_test.model is not None
+    proxied_endpoints = await get_traefik_proxied_endpoints(ops_test)
+    assert app_name in proxied_endpoints
+
+    response = requests.get(f"{proxied_endpoints[app_name]['url']}/metrics")
+    assert response.status_code == 200

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -7,11 +7,12 @@ from unittest.mock import patch
 
 import ops
 import yaml
-from blackbox import BlackboxExporterApi, WorkloadManager
-from charm import BlackboxExporterCharm
 from helpers import k8s_resource_multipatch, tautology
 from ops.model import ActiveStatus, BlockedStatus
 from ops.testing import Harness
+
+from blackbox import BlackboxExporterApi, WorkloadManager
+from charm import BlackboxExporterCharm
 
 ops.testing.SIMULATE_CAN_CONNECT = True
 


### PR DESCRIPTION
This PR proposes a fix for https://github.com/canonical/blackbox-exporter-k8s-operator/issues/36.
The ERR_TOO_MANY_REDIRECTS happens because, when the traefik relation is created, the self.external_url gets changed to `http://traefik-ip/juju-model-blackbox`.
This causes blackbox_exporter to be launched with `–web.external-url=http://traefik-ip/juju-model-blackbox`. Hence when we try to curl `http://blackbox-unit:9115`, blackbox ends up serving an html page pointing to  `http://traefik-ip/juju-model-blackbox` instead of the probes list. This generates an endless loop, because the requests to traefik are redirected to http://blackbox-unit:9115 which in turns redirects to traefik.
Since traefik is already redirecting the requests to the blackbox unit, the `–web.external-url` should be kept as the internal url.
With this fix, the catalogue item redirects correctly to the blackbox view as shown below:
 
![Screenshot from 2024-08-30 17-54-31](https://github.com/user-attachments/assets/f46bb1b4-f8d5-471f-91f4-6f2b07acb7e4)
