### PR TITLE
Probe success rule

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -11,4 +11,5 @@ bases:
       channel: "22.04"
 parts:
   charm:
+    build-packages: [git, rustc, cargo]
     charm-binary-python-packages: [ops, PyYAML, cryptography, jsonschema]

--- a/src/charm.py
+++ b/src/charm.py
@@ -10,7 +10,6 @@ from typing import cast
 from urllib.parse import urlparse
 
 import yaml
-from blackbox import ConfigUpdateFailure, WorkloadManager
 from charms.catalogue_k8s.v1.catalogue import CatalogueConsumer, CatalogueItem
 from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
 from charms.loki_k8s.v1.loki_push_api import LogForwarder
@@ -31,6 +30,8 @@ from ops.model import (
     WaitingStatus,
 )
 from ops.pebble import PathError, ProtocolError
+
+from blackbox import ConfigUpdateFailure, WorkloadManager
 
 logger = logging.getLogger(__name__)
 

--- a/src/prometheus_alert_rules/probe_failure.rule
+++ b/src/prometheus_alert_rules/probe_failure.rule
@@ -1,0 +1,13 @@
+groups:
+  - name: probe_success
+    rules:
+    - alert: probe_failed
+      expr: avg_over_time(probe_success{}[10m]) < 0.5
+      for: 0m
+      labels:
+        severity: critical
+      annotations:
+        summary: Blackbox Exporter target {{ $labels.probe_target }} has failed for at least 50% of the time over the last ten minutes
+        description: >
+          Blackbox Exporter target {{ $labels.probe_target }} has failed for at least 50% of the time over the last ten minutes
+          LABELS = {{ $labels }}

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -7,11 +7,12 @@ from unittest.mock import patch
 
 import ops
 import yaml
-from blackbox import BlackboxExporterApi, WorkloadManager
-from charm import BlackboxExporterCharm
 from helpers import k8s_resource_multipatch, tautology
 from ops.model import ActiveStatus, BlockedStatus
 from ops.testing import Harness
+
+from blackbox import BlackboxExporterApi, WorkloadManager
+from charm import BlackboxExporterCharm
 
 ops.testing.SIMULATE_CAN_CONNECT = True
 


### PR DESCRIPTION
This adds an alert rule that checks the result of the probes. Currently we only have a rule to check "up" which only checks if blackbox-exporter responded which will still happen when a probe fails.