### PR TITLE
fix: don't override probes provided by multiple relations

### DIFF
--- a/lib/charms/blackbox_exporter_k8s/v0/blackbox_probes.py
+++ b/lib/charms/blackbox_exporter_k8s/v0/blackbox_probes.py
@@ -234,7 +234,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 PYDEPS = ["pydantic"]
 

--- a/lib/charms/blackbox_exporter_k8s/v0/blackbox_probes.py
+++ b/lib/charms/blackbox_exporter_k8s/v0/blackbox_probes.py
@@ -688,7 +688,8 @@ class BlackboxProbesRequirer(Object):
                 if not relation.data[relation.app]:
                     continue
                 databag = ApplicationDataModel.load(relation.data[relation.app])
-                scrape_probes = self._process_and_hash_probes(databag)
+                relation_scrape_probes = self._process_and_hash_probes(databag)
+                scrape_probes.extend(relation_scrape_probes)
             except (json.JSONDecodeError, pydantic.ValidationError, DataValidationError) as e:
                 error_message = f"Invalid probes provided in relation {relation.id}: {e}"
                 errors.append(error_message)


### PR DESCRIPTION
## Issue
When a provider charm defines multiple relations using the `blackbox_exporter_probes` interface, it is expected that all the probes in all the relations are passed to the requirer. This is currently not happening because of a bug on how the probes are updated when iterating over the relations. Because of this, one relation probes takes precedence over the other.


## Solution
When iterating over the relations extend the list of scrape_probes to probe.
Add a test to cover this use case.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
