### PR TITLE
include port when there is no ingress

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,4 +26,5 @@ PyYAML
 lightkube >= 0.11
 lightkube-models
 
-cosl
+# prometheus_scrape lib requires cosl.rules.generic_alert_groups from version 0.0.53
+cosl >= 0.0.53

--- a/src/scrape_config_builder.py
+++ b/src/scrape_config_builder.py
@@ -79,6 +79,7 @@ class ScrapeConfigBuilder:
                 {"source_labels": ["__address__"], "target_label": "__param_target"},
                 {"source_labels": ["__param_target"], "target_label": "instance"},
                 {"source_labels": ["__param_target"], "target_label": "probe_target"},
+                # In our case, the external url is never going to have basic auth, so taking netloc should be safe
                 {"target_label": "__address__", "replacement": external_url.netloc},
             ]
 

--- a/src/scrape_config_builder.py
+++ b/src/scrape_config_builder.py
@@ -79,7 +79,7 @@ class ScrapeConfigBuilder:
                 {"source_labels": ["__address__"], "target_label": "__param_target"},
                 {"source_labels": ["__param_target"], "target_label": "instance"},
                 {"source_labels": ["__param_target"], "target_label": "probe_target"},
-                {"target_label": "__address__", "replacement": external_url.hostname},
+                {"target_label": "__address__", "replacement": external_url.netloc},
             ]
 
         return merged_scrape_configs


### PR DESCRIPTION
When we are not related to ingress, the probe scrape job sends its address without the port, which causes all scrapes to fail. Thus we should include the port.