### PR TITLE
Update `charmcraft.yaml` to use the rock image

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -39,7 +39,7 @@ resources:
   blackbox-exporter-image:
     type: oci-image
     description: OCI image for Blackbox Exporter
-    upstream-source: quay.io/prometheus/blackbox-exporter:v0.24.0
+    upstream-source: ubuntu/blackbox-exporter:0.26-24.04
 
 provides:
   self-metrics-endpoint:


### PR DESCRIPTION
## Issue
We currently use the upstream provided OCI image for `blackbox-exporter`, which is not included in oci-factory daily vulnerability scans.

## Solution
Use the rock image (version `0.26-24.04`) instead.
