### PR TITLE
fix: use correct port in prometheus targets

### DIFF
--- a/src/scrape_config_builder.py
+++ b/src/scrape_config_builder.py
@@ -65,6 +65,7 @@ class ScrapeConfigBuilder:
         """
         external_url = urlparse(self.external_url)
         probes_path = f"{external_url.path.rstrip('/')}/probe"
+        external_url_port = f":{external_url.port}" if external_url.port else ""
 
         file_probes_scrape_jobs_dict = yaml.safe_load(file_probes) if file_probes else {}
 
@@ -81,7 +82,7 @@ class ScrapeConfigBuilder:
                 {"source_labels": ["__param_target"], "target_label": "probe_target"},
                 {
                     "target_label": "__address__",
-                    "replacement": f"{external_url.hostname}:{external_url.port or ''}",
+                    "replacement": f"{external_url.hostname}{external_url_port}",
                 },
             ]
 

--- a/src/scrape_config_builder.py
+++ b/src/scrape_config_builder.py
@@ -79,7 +79,10 @@ class ScrapeConfigBuilder:
                 {"source_labels": ["__address__"], "target_label": "__param_target"},
                 {"source_labels": ["__param_target"], "target_label": "instance"},
                 {"source_labels": ["__param_target"], "target_label": "probe_target"},
-                {"target_label": "__address__", "replacement": external_url.hostname},
+                {
+                    "target_label": "__address__",
+                    "replacement": f"{external_url.hostname}:{external_url.port or ''}",
+                },
             ]
 
         return merged_scrape_configs

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -60,6 +60,22 @@ async def can_blackbox_probe(
     return response.code == 200 and "probe_success 1" in str(response.read())
 
 
+async def are_prometheus_targets_up(
+    ops_test: OpsTest,
+    app_name: str,
+    unit_num: int = 0,
+):
+    address = await get_unit_address(ops_test, app_name, unit_num)
+    url = f"http://{address}:9090"
+    response = urllib.request.urlopen(f"{url}/api/v1/targets", data=None)
+    if response.code != 200:
+        return False
+    response_data = response.read().decode("utf-8")
+    response_json = json.loads(response_data)
+    targets = response_json.get("data", {}).get("activeTargets", [])
+    return all(target["health"] == "up" for target in targets)
+
+
 async def get_blackbox_config_from_file(
     ops_test: OpsTest, app_name: str, container_name: str, config_file_path: str
 ) -> Tuple[Optional[int], str, str]:

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -60,7 +60,7 @@ async def can_blackbox_probe(
     return response.code == 200 and "probe_success 1" in str(response.read())
 
 
-async def are_prometheus_targets_up(
+async def all_prometheus_targets_up(
     ops_test: OpsTest,
     app_name: str,
     unit_num: int = 0,

--- a/tests/integration/test_prometheus_integration.py
+++ b/tests/integration/test_prometheus_integration.py
@@ -9,7 +9,7 @@ import pytest
 import sh
 import yaml
 from helpers import (
-    are_prometheus_targets_up,
+    all_prometheus_targets_up,
     can_blackbox_probe,
     is_blackbox_up,
 )
@@ -83,4 +83,4 @@ async def test_integrate_prometheus(ops_test: OpsTest):
         apps=[app_name, "prometheus"], status="active", timeout=1000
     )
     time.sleep(60)  # wait for the 1m scrape time
-    assert await are_prometheus_targets_up(ops_test, "prometheus")
+    assert await all_prometheus_targets_up(ops_test, "prometheus")

--- a/tests/integration/test_prometheus_integration.py
+++ b/tests/integration/test_prometheus_integration.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+import logging
+import time
+from pathlib import Path
+
+import pytest
+import sh
+import yaml
+from helpers import (
+    are_prometheus_targets_up,
+    can_blackbox_probe,
+    is_blackbox_up,
+)
+from pytest_operator.plugin import OpsTest
+
+# pyright: reportAttributeAccessIssue = false
+
+logger = logging.getLogger(__name__)
+
+METADATA = yaml.safe_load(Path("./charmcraft.yaml").read_text())
+app_name = METADATA["name"]
+resources = {
+    "blackbox-exporter-image": METADATA["resources"]["blackbox-exporter-image"]["upstream-source"]
+}
+resources_arg = [
+    f"blackbox-exporter-image={resources['blackbox-exporter-image']}",
+]
+blackbox_probes = {
+    "scrape_configs": [
+        {
+            "job_name": "prometheus-website",
+            "metrics_path": "/probe",
+            "params": {"module": ["http_2xx"]},
+            "static_configs": [{"targets": ["http://prometheus.io", "https://prometheus.io"]}],
+        }
+    ]
+}
+
+
+@pytest.mark.setup
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy(ops_test: OpsTest, charm_under_test):
+    """Build the charm-under-test and deploy it together with related charms.
+
+    Assert on the unit status before any relations/configurations take place.
+    """
+    assert ops_test.model
+    # deploy charm from local source folder
+    sh.juju.deploy(
+        charm_under_test,
+        app_name,
+        model=ops_test.model.name,
+        resource=resources_arg,
+        trust=True,
+    )
+    sh.juju.deploy(
+        "prometheus-k8s",
+        "prometheus",
+        model=ops_test.model.name,
+        channel="latest/edge",
+        trust=True,
+    )
+    await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
+    await ops_test.model.applications[app_name].set_config(
+        {"probes_file": yaml.dump(blackbox_probes)}
+    )
+    assert ops_test.model.applications[app_name].units[0].workload_status == "active"
+    assert await is_blackbox_up(ops_test, app_name)
+
+
+@pytest.mark.abort_on_fail
+async def test_probe_endpoint(ops_test: OpsTest):
+    assert await can_blackbox_probe(ops_test, app_name, 0)
+
+
+@pytest.mark.abort_on_fail
+async def test_integrate_prometheus(ops_test: OpsTest):
+    assert ops_test.model
+    sh.juju.relate(app_name, "prometheus", model=ops_test.model.name)
+    await ops_test.model.wait_for_idle(
+        apps=[app_name, "prometheus"], status="active", timeout=1000
+    )
+    time.sleep(60)  # wait for the 1m scrape time
+    assert await are_prometheus_targets_up(ops_test, "prometheus")


### PR DESCRIPTION
## Issue
Close #54 


## Solution
Use the port when creating the scrape jobs for Prometheus. This PR also adds an integration test to verify the behavior.

