### PR TITLE
feat: add track to inputs for promote workflow

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -10,6 +10,11 @@ on:
           - edge -> beta
           - beta -> candidate
           - candidate -> stable
+      track:
+        type: string
+        description: Track to promote
+        default: latest
+        required: false
 
 jobs:
   promote:
@@ -17,4 +22,5 @@ jobs:
     uses: canonical/observability/.github/workflows/charm-promote.yaml@v1
     with:
       promotion: ${{ github.event.inputs.promotion }}
+      track: ${{ github.event.inputs.track }}
     secrets: inherit


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
In order to promote the charm on track 2 from edge to beta, beta to candidate, and candidate to stable, we can't rely on the current local promote workflow because that doesn't accept a track input. So the central promote job is triggered with the default track of `stable`, which means we can't promote track 2.
 

## Solution
<!-- A summary of the solution addressing the above issue -->
This PR adds a workflow dispatch input of type string called track. The result is that on dispatch, you can specify the target track.
<img width="745" height="781" alt="image" src="https://github.com/user-attachments/assets/4b4855a1-28fe-427e-a9fd-c33f9b7a7959" />
This change was tested with the O11y tester charm [here](https://github.com/canonical/o11y-tester-operator/actions/runs/22191659558/job/64180892201).
## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
