### PR TITLE
feat: add terraform module for blackbox-exporter-k8s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,9 @@ venv
 .idea
 .vscode
 .hypothesis/*
+
+# Terraform
+terraform/.terraform/
+terraform/.terraform.lock.hcl
+terraform/*.tfstate
+terraform/*.tfstate.backup

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,44 @@
+# Terraform module for blackbox-exporter-k8s
+
+This is a Terraform module facilitating the deployment of blackbox-exporter-k8s charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs).
+
+<!-- BEGIN_TF_DOCS -->
+
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
+| <a name="requirement_juju"></a> [juju](#requirement\_juju) | ~> 1.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_juju"></a> [juju](#provider\_juju) | 1.5.0 |
+
+## Modules
+
+No modules.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_app_name"></a> [app\_name](#input\_app\_name) | Name to give the deployed application | `string` | `"blackbox-exporter"` | no |
+| <a name="input_channel"></a> [channel](#input\_channel) | Channel that the charm is deployed from | `string` | n/a | yes |
+| <a name="input_config"></a> [config](#input\_config) | Map of the charm configuration options | `map(string)` | `{}` | no |
+| <a name="input_constraints"></a> [constraints](#input\_constraints) | String listing constraints for this application | `string` | `"arch=amd64"` | no |
+| <a name="input_model_uuid"></a> [model\_uuid](#input\_model\_uuid) | Reference to an existing model resource or data source for the model to deploy to | `string` | n/a | yes |
+| <a name="input_revision"></a> [revision](#input\_revision) | Revision number of the charm | `number` | `null` | no |
+| <a name="input_units"></a> [units](#input\_units) | Unit count/scale | `number` | `1` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_app_name"></a> [app\_name](#output\_app\_name) | n/a |
+| <a name="output_provides"></a> [provides](#output\_provides) | n/a |
+| <a name="output_requires"></a> [requires](#output\_requires) | n/a |
+<!-- END_TF_DOCS -->

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -3,8 +3,6 @@
 This is a Terraform module facilitating the deployment of blackbox-exporter-k8s charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs).
 
 <!-- BEGIN_TF_DOCS -->
-
-
 ## Requirements
 
 | Name | Version |
@@ -16,7 +14,7 @@ This is a Terraform module facilitating the deployment of blackbox-exporter-k8s 
 
 | Name | Version |
 |------|---------|
-| <a name="provider_juju"></a> [juju](#provider\_juju) | 1.5.0 |
+| <a name="provider_juju"></a> [juju](#provider\_juju) | ~> 1.0 |
 
 ## Modules
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,14 @@
+resource "juju_application" "blackbox_exporter" {
+  name        = var.app_name
+  config      = var.config
+  constraints = var.constraints
+  model_uuid  = var.model_uuid
+  trust       = true
+  units       = var.units
+
+  charm {
+    name     = "blackbox-exporter-k8s"
+    channel  = var.channel
+    revision = var.revision
+  }
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,19 @@
+output "app_name" {
+  value = juju_application.blackbox_exporter.name
+}
+
+output "provides" {
+  value = {
+    self_metrics_endpoint = "self-metrics-endpoint"
+    grafana_dashboard     = "grafana-dashboard"
+  }
+}
+
+output "requires" {
+  value = {
+    catalogue = "catalogue"
+    ingress   = "ingress"
+    logging   = "logging"
+    probes    = "probes"
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,48 @@
+variable "app_name" {
+  description = "Name to give the deployed application"
+  type        = string
+  default     = "blackbox-exporter"
+}
+
+variable "channel" {
+  description = "Channel that the charm is deployed from"
+  type        = string
+
+  validation {
+    condition     = startswith(var.channel, "dev/")
+    error_message = "The track of the channel must be 'dev/'. e.g. 'dev/edge'."
+  }
+}
+
+variable "config" {
+  description = "Map of the charm configuration options"
+  type        = map(string)
+  default     = {}
+}
+
+# We use constraints to set AntiAffinity in K8s
+# https://discourse.charmhub.io/t/pod-priority-and-affinity-in-juju-charms/4091/13?u=jose
+variable "constraints" {
+  description = "String listing constraints for this application"
+  type        = string
+  # FIXME: Passing an empty constraints value to the Juju Terraform provider currently
+  # causes the operation to fail due to https://github.com/juju/terraform-provider-juju/issues/344
+  default = "arch=amd64"
+}
+
+variable "model_uuid" {
+  description = "Reference to an existing model resource or data source for the model to deploy to"
+  type        = string
+}
+
+variable "revision" {
+  description = "Revision number of the charm"
+  type        = number
+  default     = null
+}
+
+variable "units" {
+  description = "Unit count/scale"
+  type        = number
+  default     = 1
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 1.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Add a Terraform module for deploying blackbox-exporter-k8s, following the canonical pattern established by [grafana-k8s-operator](https://github.com/canonical/grafana-k8s-operator/tree/main/terraform) and [alertmanager-k8s-operator](https://github.com/canonical/alertmanager-k8s-operator/tree/main/terraform).

### Changes
- `terraform/main.tf`: `juju_application` resource with trust enabled
- `terraform/variables.tf`: Standard inputs (app_name, channel with dev/ track validation, config, constraints, model_uuid, revision, units)
- `terraform/outputs.tf`: app_name + provides/requires endpoint maps derived from charmcraft.yaml
- `terraform/versions.tf`: Terraform >= 1.5, juju provider ~> 1.0
- `terraform/README.md`: Auto-generated via `terraform-docs`
- `.gitignore`: Terraform state/lock entries

### Validation
- `terraform validate` passes
- `terraform-docs` generated README successfully

---

Supersedes #71 — rewritten from scratch to align with the current module conventions used across the observability charms.