### PR TITLE
Add support for https scheme

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -208,7 +208,7 @@ class BlackboxExporterCharm(CharmBase):
         # Make sure the external url is valid
         if external_url := self._external_url:
             parsed = urlparse(external_url)
-            if not (parsed.scheme in ["http"] and parsed.hostname):
+            if not (parsed.scheme in ["http", "https"] and parsed.hostname):
                 # This shouldn't happen
                 logger.error(
                     "Invalid external url: %s; must include scheme and hostname.",


### PR DESCRIPTION
## Issue
https://github.com/canonical/blackbox-exporter-k8s-operator/issues/101


## Solution
Add "https" scheme in addition to "http"


## Context
bb-exporter in blocked state when using COS-HA with TLS enabled


## Testing Instructions


## Upgrade Notes
