### PR TITLE
fix: Allow HTTPS in external URL

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -208,7 +208,7 @@ class BlackboxExporterCharm(CharmBase):
         # Make sure the external url is valid
         if external_url := self._external_url:
             parsed = urlparse(external_url)
-            if not (parsed.scheme in ["http"] and parsed.hostname):
+            if not (parsed.scheme in ["http", "https"] and parsed.hostname):
                 # This shouldn't happen
                 logger.error(
                     "Invalid external url: %s; must include scheme and hostname.",

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -99,6 +99,20 @@ class TestWithoutInitialHooks(unittest.TestCase):
 
         self.assertEqual(self.harness.model.unit.name, "blackbox-exporter-k8s/0")
 
+    @k8s_resource_multipatch
+    @patch("charm.BlackboxExporterCharm._external_url", new="https://0.0.0.0/")
+    @patch.object(WorkloadManager, "_blackbox_exporter_version", property(lambda *_: "0.0.0"))
+    @patch.object(WorkloadManager, "push_config")
+    def test_unit_status_around_pebble_ready_with_https_external_url(self, *unused):
+        # before pebble_ready, status should be "maintenance"
+        self.assertIsInstance(self.harness.charm.unit.status, ops.model.MaintenanceStatus)
+
+        # after pebble_ready, with an https external url, status should be "active"
+        self.harness.container_pebble_ready(self.container_name)
+        self.assertIsInstance(self.harness.charm.unit.status, ops.model.ActiveStatus)
+
+        self.assertEqual(self.harness.model.unit.name, "blackbox-exporter-k8s/0")
+
 
 @pytest.mark.usefixtures("patch_all")
 def test_smoke(context, container):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -104,14 +104,8 @@ class TestWithoutInitialHooks(unittest.TestCase):
     @patch.object(WorkloadManager, "_blackbox_exporter_version", property(lambda *_: "0.0.0"))
     @patch.object(WorkloadManager, "push_config")
     def test_unit_status_around_pebble_ready_with_https_external_url(self, *unused):
-        # before pebble_ready, status should be "maintenance"
-        self.assertIsInstance(self.harness.charm.unit.status, ops.model.MaintenanceStatus)
-
-        # after pebble_ready, with an https external url, status should be "active"
         self.harness.container_pebble_ready(self.container_name)
         self.assertIsInstance(self.harness.charm.unit.status, ops.model.ActiveStatus)
-
-        self.assertEqual(self.harness.model.unit.name, "blackbox-exporter-k8s/0")
 
 
 @pytest.mark.usefixtures("patch_all")


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Fixes https://github.com/canonical/blackbox-exporter-k8s-operator/issues/101

## Solution
<!-- A summary of the solution addressing the above issue -->
Add `https` to the allowable schemes. This is better than removing the scheme check because it avoids scenarios where the external URL has no scheme.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
This requires a backport to track/2

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
`tox -e unit -- tests/unit/test_charm.py`

Release an ephemeral version for the FE to test:
```
2        ubuntu 24.04 (amd64)  stable       b63d579           44          blackbox-exporter-image (r8)
                               edge         c7ddaf8           48          blackbox-exporter-image (r8)
                               edge/pr-105  rev48-2-gb83f505  57          blackbox-exporter-image (r8)  2026-07-12T00:00:00Z
```

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
