### PR TITLE
fix(track/2): Allow HTTPS in external URL

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -189,7 +189,7 @@ class BlackboxExporterCharm(CharmBase):
         # Make sure the external url is valid
         if external_url := self._external_url:
             parsed = urlparse(external_url)
-            if not (parsed.scheme in ["http"] and parsed.hostname):
+            if not (parsed.scheme in ["http", "https"] and parsed.hostname):
                 # This shouldn't happen
                 logger.error(
                     "Invalid external url: %s; must include scheme and hostname.",

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -96,3 +96,11 @@ class TestWithoutInitialHooks(unittest.TestCase):
         self.assertIsInstance(self.harness.charm.unit.status, ops.model.ActiveStatus)
 
         self.assertEqual(self.harness.model.unit.name, "blackbox-exporter-k8s/0")
+
+    @k8s_resource_multipatch
+    @patch("charm.BlackboxExporterCharm._external_url", new="https://0.0.0.0/")
+    @patch.object(WorkloadManager, "_blackbox_exporter_version", property(lambda *_: "0.0.0"))
+    @patch.object(WorkloadManager, "push_config")
+    def test_unit_status_around_pebble_ready_with_https_external_url(self, *unused):
+        self.harness.container_pebble_ready(self.container_name)
+        self.assertIsInstance(self.harness.charm.unit.status, ops.model.ActiveStatus)


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Backport for this PR:
- https://github.com/canonical/blackbox-exporter-k8s-operator/pull/104/

into track/2
