### PR TITLE
docs: update show-config example for Juju 3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ To verify Blackbox Exporter is using the expected configuration you can use the
 [`show-config`](https://charmhub.io/blackbox-exporter-k8s/actions#show-config) action:
 
 ```shell
-juju run-action blackbox-exporter-k8s/0 show-config --wait
+juju run blackbox-exporter-k8s/0 show-config
 ```
 
 To configure the actual probes, there first needs to be a Prometheus relation:


### PR DESCRIPTION
## Summary
- Update the README `show-config` example from deprecated `juju run-action ... --wait` to Juju 3.x `juju run`.

## Test plan
- [x] Grep confirms no remaining `run-action` usages in the README
- [x] Action is still defined in `charmcraft.yaml` / charm code